### PR TITLE
🆕 Supports annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ final class AkkeyView: UIView, AutoPreviewable {
     // do something
 }
 ```
+There is another way to generate using annotations.
+```swift
+// sourcery: AutoPreviewable, xibLess
+final class AkkeyView: UIView {
+    // do something
+}
+```
 By default, processing is performed assuming that there is an XIB file with the same name as the class name.  
 If the XIB file does not exist, specify as follows.
 ```swift

--- a/Sourcery/templates/AutoPreviewable.stencil
+++ b/Sourcery/templates/AutoPreviewable.stencil
@@ -2,7 +2,7 @@ import UIKit
 #if canImport(SwiftUI) && DEBUG
 import SwiftUI
 
-{% for type in types.implementing.AutoPreviewable|class %}
+{% for type in types.types|class where type.implements.AutoPreviewable or type|annotated:"AutoPreviewable" %}
 {% if type.isFinal %}
 @available(iOS 13, *)
 struct {{ type.name }}Previews: PreviewProvider {


### PR DESCRIPTION
Hi @AkkeyLab,

I have many possibilities and some ideas for this project! But difficulty adding any features by its testing way.

Your protocol is empty and it can be generate without it. The PR adding annotations like this,

```swift
// sourcery: AutoPreviewable,
final class View: UIView {}
```

I'm thinking of the testing plan it wrote all cases on Unit Test scheme and to confirm the result of building by CI (e.g. GitHub Actions). But the protocol ways are failed with conflict induced by the targets when it imports testable targets...¯\_(ツ)_/¯

Please let me know if you have questions about any of this. Thanks.